### PR TITLE
Remove Windows builds from Sipnet CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  # try to build SIPNET on Windows, Ubuntu, MacOS
+  # try to build SIPNET on Ubuntu & MacOS
   build:
     strategy:
       fail-fast: false
@@ -18,7 +18,6 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - ubuntu-20.04
-          - windows-latest
 
     runs-on: ${{ matrix.OS }}
 
@@ -46,7 +45,6 @@ jobs:
         exit 1
     # check whether niwot.out has changed
     - name: Check whether niwot.out has changed 
-      if: runner.os != 'Windows' #fails b/c line endings?
       shell: bash
       run: |
          if git diff --exit-code Sites/Niwot/niwot.out; then


### PR DESCRIPTION
While implementing & reviewing #17 and #18 it became clear that supporting Windows builds would require a lot of exceptions. Given that Windows Subsystem for Linux provides a viable option for Windows users this PR proposes removing support for windows builds.

Note: will also require removing Windows build from branch ruleset.