### PR TITLE
Move compile time flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,9 @@ make testrun
 # Clean after tests are run
 make testclean
 ```
+
+If changes are made to the `modelStructure.h` file and unit tests are failing, try running the update script as shown below. Consider running this script even if unit tests _are not_ failing.
+```shell
+# Run this command from the root directory to update unit test versions of modelStructures.h
+tests/update_model_structures.sh
+```

--- a/modelStructures.h
+++ b/modelStructures.h
@@ -1,8 +1,10 @@
 //
-// This file is inteneded to hold settings for different model structure options,
+// This file is intended to hold settings for different model structure options,
 // implemented as compile-time flags. The options are here (with nothing else) to
 // improve testability.
 //
+// If this file is changed, consider running tests/update_model_structures.sh to update
+// the corresponding unit test versions of this file.
 
 #ifndef MODEL_STRUCTURES_H
 #define MODEL_STRUCTURES_H
@@ -14,5 +16,10 @@
 // Read in and process agronomic events. SIPNET expects a file named events.in to exist, though
 // unit tests may use other names.
 
+// have extra litter pool, in addition to soil c pool
+#define LITTER_POOL 0
+
+// Whether we model root dynamics
+#define ROOTS 1
 
 #endif //MODEL_STRUCTURES_H

--- a/sipnet.c
+++ b/sipnet.c
@@ -96,7 +96,7 @@
 #define SOIL_PHENOL 0 && !GDD
 // use soil temp. to determine leaf growth? (note: mutually exclusive with GDD)
 
-#define LITTER_POOL 0
+// LITTER_POOL moved to modelStructures.h
 // have extra litter pool, in addition to soil c pool
 
 #define SOIL_MULTIPOOL 0 && !LITTER_POOL
@@ -120,7 +120,7 @@
 #define STOICHIOMETRY 0 && MICROBES
 // do we utilize stoichometric considerations for the microbial pool?
 
-#define ROOTS 1
+// ROOTS moved to modelStructures.h
 // do we model root dynamics?
 
 

--- a/tests/sipnet/test_events/modelStructures.h
+++ b/tests/sipnet/test_events/modelStructures.h
@@ -1,8 +1,13 @@
 //
-// This file is inteneded to hold settings for different model structure options,
+// DO NOT ADD CUSTOM CODE TO THIS FILE (other than #define overrides for unit tests)
+// IT MAY BE OVERWRITTEN BY update_model_structures.sh
+//
+// This file is intended to hold settings for different model structure options,
 // implemented as compile-time flags. The options are here (with nothing else) to
 // improve testability.
 //
+// If this file is changed, consider running tests/update_model_structures.sh to update
+// the corresponding unit test versions of this file.
 
 #ifndef MODEL_STRUCTURES_H
 #define MODEL_STRUCTURES_H
@@ -11,7 +16,13 @@
 // See also sipnet.c for other options (that should be moved here if/when testing is added)
 
 #define EVENT_HANDLER 1
-// Read in and process agronomic events. Expects a file named <FILENAME>.event to exist.
+// Read in and process agronomic events. SIPNET expects a file named events.in to exist, though
+// unit tests may use other names.
 
+// have extra litter pool, in addition to soil c pool
+#define LITTER_POOL 0
+
+// Whether we model root dynamics
+#define ROOTS 1
 
 #endif //MODEL_STRUCTURES_H

--- a/tests/update_model_structures.sh
+++ b/tests/update_model_structures.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Run this script from the root SIPNET directory with the command:
+# > tests/update_model_structures.sh
+
+# Name of the file containing #define compiler switches
+STRUCTURES_FILE="modelStructures.h"
+
+# Get the path to the current directory's STRUCTURES_FILE - that is,
+# the production version
+PROD_MODEL_STRUCTURES="./${STRUCTURES_FILE}"
+
+# Check if the current directory has the base model_structures.h
+if [[ ! -f $PROD_MODEL_STRUCTURES ]]; then
+    echo "Error: ${STRUCTURES_FILE} not found in the current directory."
+    exit 1
+fi
+
+# Define the awk script to update #define values; this will be called on each test
+# version of STRUCTURES_FILE
+read -r -d '' AWK_SCRIPT << 'EOF'
+BEGIN {
+    FS = "[ \t]+";  # Set field separator to handle spaces or tabs
+    define_regex = "^#define";
+    skip_regex = "MODEL_STRUCTURES_H";
+}
+
+# Process the test structures file and store the #define values in an associative array
+FNR == NR {
+    if ($1 ~ define_regex && $2 !~ skip_regex) {
+        name = $2;   # The second field is the name of the #define
+        value = $3;  # The third field is the value of the #define
+        defines[name] = value;
+    }
+    next;
+}
+
+# Update the new file with the old #define values
+{
+    if ($1 ~ define_regex && $2 !~ skip_regex) {
+        name = $2;
+        if (name in defines) {
+            printf "#define %s %s\n", name, defines[name];
+            next;
+        }
+    }
+    # Print the line as-is if no overwrite is needed
+    print $0;
+}
+EOF
+
+# Find and process all target files in subdirectories
+find . -type f -name "$STRUCTURES_FILE" -mindepth 2 | while read -r file; do
+    echo "Processing: $file"
+
+    # Create a backup of the original file
+    cp "$file" "${file}.bak"
+
+    # Add a warning at the top, then update defines
+    {
+        echo "//"
+        echo "// DO NOT ADD CUSTOM CODE TO THIS FILE (other than #define overrides for unit tests)"
+        echo "// IT MAY BE OVERWRITTEN BY update_model_structures.sh"
+        cat "$PROD_MODEL_STRUCTURES"
+    } | awk "$AWK_SCRIPT" "$file" - > "${file}.tmp"
+
+    # Overwrite the target file with the updated content
+    mv "${file}.tmp" "$file"
+
+    echo "Updated: $file"
+done


### PR DESCRIPTION
This PR moves two compile switches from `sipnet.c` to the new `modelStructures.h` file. No tests have been added for that functionality, but this should be done at some later date.

Also, it adds a script that can be run to update version of `modelStructures.h` in the unit test directories whenever changes are made to the "production" version. This script was run and the updated test version is in this PR.