### PR TITLE
SIP51 Allow empty or nonexistent event files

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,1 +1,2 @@
 -Isrc
+-Itests

--- a/src/sipnet/events.c
+++ b/src/sipnet/events.c
@@ -160,8 +160,6 @@ EventNode **readEventData(char *eventFile, int numLocs) {
   char line[EVENT_LINE_SIZE];
   EventNode *curr, *next;
 
-  printf("Begin reading event data from file %s\n", eventFile);
-
   EventNode **events =
       (EventNode **)calloc(sizeof(EventNode *), numLocs * sizeof(EventNode *));
 
@@ -169,8 +167,11 @@ EventNode **readEventData(char *eventFile, int numLocs) {
   if (access(eventFile, F_OK) != 0) {
     // no file found, which is fine; we're done, a vector of NULL is what we
     // want for events
+    printf("No event file found, assuming no events");
     return events;
   }
+
+  printf("Begin reading event data from file %s\n", eventFile);
 
   FILE *in = openFile(eventFile, "r");
 

--- a/src/sipnet/events.c
+++ b/src/sipnet/events.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>  // for access()
 #include "exitCodes.h"
 #include "common/util.h"
 
@@ -163,13 +164,21 @@ EventNode **readEventData(char *eventFile, int numLocs) {
 
   EventNode **events =
       (EventNode **)calloc(sizeof(EventNode *), numLocs * sizeof(EventNode *));
-  // status of the read
+
+  // Check for a non-empty file
+  if (access(eventFile, F_OK) != 0) {
+    // no file found, which is fine; we're done, a vector of NULL is what we
+    // want for events
+    return events;
+  }
+
   FILE *in = openFile(eventFile, "r");
 
   if (fgets(line, EVENT_LINE_SIZE, in) == NULL) {
-    printf("Error reading event file: no event data in %s\n", eventFile);
-    exit(1);
+    // Again, this is fine - just return the empty events array
+    return events;
   }
+
   int numRead = sscanf(line, "%d %d %d %s %n", &loc, &year, &day, eventTypeStr,
                        &numBytes);
   if (numRead != NUM_EVENT_CORE_PARAMS) {

--- a/src/sipnet/sipnet.c
+++ b/src/sipnet/sipnet.c
@@ -2517,7 +2517,7 @@ void updateTrackers(double oldSoilWater) {
 //
 // Process events for current location/year/day
 #if EVENT_HANDLER
-void processEvents() {
+void processEvents(void) {
   // If locEvent starts off NULL, this function will just fall through, as it
   // should.
   const int year = climate->year;
@@ -2532,7 +2532,7 @@ void processEvents() {
       printf("Agronomic event found for loc: %d year: %d day: %d that does not "
              "have a corresponding record in the climate file\n",
              locEvent->year, locEvent->year, locEvent->day);
-      exit(1);
+      exit(EXIT_CODE_INPUT_FILE_ERROR);
     }
     switch (locEvent->type) {
       // Implementation TBD, as we enable the various event types

--- a/tests/.clang-tidy
+++ b/tests/.clang-tidy
@@ -1,0 +1,4 @@
+# Allow inclusion of *.c files in tests, and ease off of free() and NULL dereference checks
+Checks: '-bugprone-suspicious-include,
+-clang-analyzer-unix.Malloc,
+-clang-analyzer-core.NullDereference'

--- a/tests/sipnet/test_events_infrastructure/testEventInfra.c
+++ b/tests/sipnet/test_events_infrastructure/testEventInfra.c
@@ -6,12 +6,13 @@
 #include "utils/tUtils.h"
 #include "sipnet/events.c"
 
-int checkEvent(EventNode* event, int loc, int year, int day, enum EventType type) {
-  int success =
-    event->loc == loc &&
-    event->year == year &&
-    event->day == day &&
-    event->type == type;
+int checkEvent(EventNode *event, int loc, int year, int day,
+               enum EventType type) {
+  if (!event) {
+    return 1;
+  }
+  int success = event->loc == loc && event->year == year && event->day == day &&
+                event->type == type;
   if (!success) {
     printf("Error checking event\n");
     printEvent(event);
@@ -20,83 +21,63 @@ int checkEvent(EventNode* event, int loc, int year, int day, enum EventType type
   return 0;
 }
 
-int checkHarvestParams(
-  HarvestParams *params, double fracRemAbove,
-  double fracRemBelow,
-  double fracTransAbove,
-  double fracTransBelow
-) {
-  return !(
-    compareDoubles(params->fractionRemovedAbove, fracRemAbove) &&
-    compareDoubles(params->fractionRemovedBelow, fracRemBelow) &&
-    compareDoubles(params->fractionTransferredAbove, fracTransAbove) &&
-    compareDoubles(params->fractionTransferredBelow, fracTransBelow)
-    );
+int checkHarvestParams(HarvestParams *params, double fracRemAbove,
+                       double fracRemBelow, double fracTransAbove,
+                       double fracTransBelow) {
+  return !(compareDoubles(params->fractionRemovedAbove, fracRemAbove) &&
+           compareDoubles(params->fractionRemovedBelow, fracRemBelow) &&
+           compareDoubles(params->fractionTransferredAbove, fracTransAbove) &&
+           compareDoubles(params->fractionTransferredBelow, fracTransBelow));
 }
 
-int checkIrrigationParams(
-  IrrigationParams *params,
-  double amountAdded,
-  int method
-  ) {
-  return !(
-    compareDoubles(params->amountAdded, amountAdded) &&
-    params->method == method
-    );
+int checkIrrigationParams(IrrigationParams *params, double amountAdded,
+                          int method) {
+  return !(compareDoubles(params->amountAdded, amountAdded) &&
+           params->method == method);
 }
 
-int checkFertilizationParams(
-  FertilizationParams *params,
-  double orgN,
-  double orgC,
-  double minN
-) {
-  return !(
-    compareDoubles(params->orgN, orgN) &&
-    compareDoubles(params->orgC, orgC) &&
-    compareDoubles(params->minN, minN)
-    );
+int checkFertilizationParams(FertilizationParams *params, double orgN,
+                             double orgC, double minN) {
+  return !(compareDoubles(params->orgN, orgN) &&
+           compareDoubles(params->orgC, orgC) &&
+           compareDoubles(params->minN, minN));
 }
 
-int checkPlantingParams(
-  PlantingParams *params, int emergenceLag, double addedC, double addedN
-  ) {
-  return !(
-    params->emergenceLag == emergenceLag &&
-    compareDoubles(params->addedC, addedC) &&
-    compareDoubles(params->addedN, addedN)
-    );
+int checkPlantingParams(PlantingParams *params, int emergenceLag, double addedC,
+                        double addedN) {
+  return !(params->emergenceLag == emergenceLag &&
+           compareDoubles(params->addedC, addedC) &&
+           compareDoubles(params->addedN, addedN));
 }
 
-int checkTillageParams(
-  TillageParams *params,
-  double fracLitterTransferred,
-  double somDecompModifier,
-  double litterDecompModifier
-  ) {
-  return !(
-    compareDoubles(params->fractionLitterTransferred, fracLitterTransferred) &&
-    compareDoubles(params->somDecompModifier, somDecompModifier) &&
-    compareDoubles(params->litterDecompModifier, litterDecompModifier)
-    );
+int checkTillageParams(TillageParams *params, double fracLitterTransferred,
+                       double somDecompModifier, double litterDecompModifier) {
+  return !(compareDoubles(params->fractionLitterTransferred,
+                          fracLitterTransferred) &&
+           compareDoubles(params->somDecompModifier, somDecompModifier) &&
+           compareDoubles(params->litterDecompModifier, litterDecompModifier));
 }
 
-int init() {
-  // char * filename = "infra_events_simple.in";
-  // if (access(filename, F_OK) == -1) {
-  //   return 1;
-  // }
-  //
-  // return copyFile(filename, "events.in");
-  return 0;
+int init(void) { return 0; }
+
+int runTestEmpty(void) {
+  int numLocs = 2;
+  int status = 0;
+  // Should return empty for no file
+  EventNode **output = readEventData("infra_events_no_file.in", numLocs);
+  status |= !((output[0] == NULL) && (output[1] == NULL));
+  output = readEventData("infra_events_empty_file.in", numLocs);
+  status |= !((output[0] == NULL) && (output[1] == NULL));
+
+  return status;
 }
 
-int runTestSimple() {
+int runTestSimple(void) {
   // Simple test with one loc, one event per type
   int numLocs = 1;
-  EventNode** output = readEventData("infra_events_simple.in", numLocs);
+  EventNode **output = readEventData("infra_events_simple.in", numLocs);
 
-  if (!output) {
+  if (!output || !output[0]) {
     return 1;
   }
 
@@ -104,27 +85,31 @@ int runTestSimple() {
   int status = 0;
   EventNode *event = output[0];
   status |= checkEvent(event, 0, 2022, 40, IRRIGATION);
-  status |= checkIrrigationParams((IrrigationParams*)event->eventParams, 5, 0);
+  status |= checkIrrigationParams((IrrigationParams *)event->eventParams, 5, 0);
   event = event->nextEvent;
   status |= checkEvent(event, 0, 2022, 40, FERTILIZATION);
-  status |= checkFertilizationParams((FertilizationParams*)event->eventParams, 15, 5,10);
+  status |= checkFertilizationParams((FertilizationParams *)event->eventParams,
+                                     15, 5, 10);
   event = event->nextEvent;
   status |= checkEvent(event, 0, 2022, 45, TILLAGE);
-  status |= checkTillageParams((TillageParams*)event->eventParams, 0.1, 0.2, 0.3);
+  status |=
+      checkTillageParams((TillageParams *)event->eventParams, 0.1, 0.2, 0.3);
   event = event->nextEvent;
   status |= checkEvent(event, 0, 2022, 46, PLANTING);
-  status |= checkPlantingParams((PlantingParams*)event->eventParams, 10, 10, 1);
+  status |=
+      checkPlantingParams((PlantingParams *)event->eventParams, 10, 10, 1);
   event = event->nextEvent;
   status |= checkEvent(event, 0, 2022, 250, HARVEST);
-  status |= checkHarvestParams((HarvestParams*)event->eventParams, 0.4, 0.1, 0.2, 0.3);
+  status |= checkHarvestParams((HarvestParams *)event->eventParams, 0.4, 0.1,
+                               0.2, 0.3);
 
   return status;
 }
 
-int runTestMulti() {
+int runTestMulti(void) {
   // More complex test; multiple locations
   int numLocs = 1;
-  EventNode** output = readEventData("infra_events_multi.in", numLocs);
+  EventNode **output = readEventData("infra_events_multi.in", numLocs);
 
   if (!output) {
     return 1;
@@ -135,60 +120,77 @@ int runTestMulti() {
   int loc = 0;
   EventNode *event = output[loc];
   status |= checkEvent(event, loc, 2024, 60, TILLAGE);
-  status |= checkTillageParams((TillageParams*)event->eventParams, 0.1, 0.2, 0.3);
+  status |=
+      checkTillageParams((TillageParams *)event->eventParams, 0.1, 0.2, 0.3);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 65, PLANTING);
-  status |= checkPlantingParams((PlantingParams*)event->eventParams, 15, 20, 5);
+  status |=
+      checkPlantingParams((PlantingParams *)event->eventParams, 15, 20, 5);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 70, IRRIGATION);
-  status |= checkIrrigationParams((IrrigationParams*)event->eventParams, 5, 1);
+  status |= checkIrrigationParams((IrrigationParams *)event->eventParams, 5, 1);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 75, FERTILIZATION);
-  status |= checkFertilizationParams((FertilizationParams*)event->eventParams, 15, 10,5);
+  status |= checkFertilizationParams((FertilizationParams *)event->eventParams,
+                                     15, 10, 5);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 250, HARVEST);
-  status |= checkHarvestParams((HarvestParams*)event->eventParams, 0.1, 0.2, 0.3, 0.4);
+  status |= checkHarvestParams((HarvestParams *)event->eventParams, 0.1, 0.2,
+                               0.3, 0.4);
 
   loc++;
   event = output[loc];
   status |= checkEvent(event, loc, 2024, 59, TILLAGE);
-  status |= checkTillageParams((TillageParams*)event->eventParams, 0.2, 0.3, 0.1);
+  status |=
+      checkTillageParams((TillageParams *)event->eventParams, 0.2, 0.3, 0.1);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 64, PLANTING);
-  status |= checkPlantingParams((PlantingParams*)event->eventParams, 15, 20, 5);
+  status |=
+      checkPlantingParams((PlantingParams *)event->eventParams, 15, 20, 5);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 69, IRRIGATION);
-  status |= checkIrrigationParams((IrrigationParams*)event->eventParams, 5, 0);
+  status |= checkIrrigationParams((IrrigationParams *)event->eventParams, 5, 0);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 74, FERTILIZATION);
-  status |= checkFertilizationParams((FertilizationParams*)event->eventParams, 5, 15,10);
+  status |= checkFertilizationParams((FertilizationParams *)event->eventParams,
+                                     5, 15, 10);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 249, HARVEST);
-  status |= checkHarvestParams((HarvestParams*)event->eventParams, 0.2, 0.3, 0.4, 0.1);
+  status |= checkHarvestParams((HarvestParams *)event->eventParams, 0.2, 0.3,
+                               0.4, 0.1);
 
   loc++;
   event = output[loc];
   status |= checkEvent(event, loc, 2024, 58, TILLAGE);
-  status |= checkTillageParams((TillageParams*)event->eventParams, 0.3, 0.1, 0.2);
+  status |=
+      checkTillageParams((TillageParams *)event->eventParams, 0.3, 0.1, 0.2);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 63, PLANTING);
-  status |= checkPlantingParams((PlantingParams*)event->eventParams, 15, 20, 5);
+  status |=
+      checkPlantingParams((PlantingParams *)event->eventParams, 15, 20, 5);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 68, IRRIGATION);
-  status |= checkIrrigationParams((IrrigationParams*)event->eventParams, 6, 1);
+  status |= checkIrrigationParams((IrrigationParams *)event->eventParams, 6, 1);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 73, FERTILIZATION);
-  status |= checkFertilizationParams((FertilizationParams*)event->eventParams, 5, 10,15);
+  status |= checkFertilizationParams((FertilizationParams *)event->eventParams,
+                                     5, 10, 15);
   event = event->nextEvent;
   status |= checkEvent(event, loc, 2024, 248, HARVEST);
-  status |= checkHarvestParams((HarvestParams*)event->eventParams, 0.3, 0.4, 0.1, 0.2);
+  status |= checkHarvestParams((HarvestParams *)event->eventParams, 0.3, 0.4,
+                               0.1, 0.2);
 
   return status;
 }
 
-int run() {
+int run(void) {
 
   int status;
+
+  status = runTestEmpty();
+  if (status) {
+    return 1;
+  }
 
   status = runTestSimple();
   if (status) {
@@ -203,20 +205,20 @@ int run() {
   return 0;
 }
 
-void cleanup() {
+void cleanup(void) {
   // Perform any cleanup as needed
   // None needed here, we can leave the copied file
 }
 
-int main() {
+int main(void) {
   int status;
-  status = init();
-  if (status) {
-    printf("Test initialization failed with status %d\n", status);
-    exit(status);
-  } else {
-    printf("Test initialized\n");
-  }
+  //  status = init();
+  //  if (status) {
+  //    printf("Test initialization failed with status %d\n", status);
+  //    exit(status);
+  //  } else {
+  printf("Test initialized\n");
+  //  }
 
   printf("Starting run()\n");
   status = run();

--- a/tests/sipnet/test_events_infrastructure/testEventInfraNeg.c
+++ b/tests/sipnet/test_events_infrastructure/testEventInfraNeg.c
@@ -1,12 +1,11 @@
 
 #include <stdio.h>
-#include <stdlib.h>
 
-#include "modelStructures.h" //NOLINT
+#include "modelStructures.h"  //NOLINT
 #include "sipnet/events.c"
 #include "utils/exitHandler.c"
 
-int run() {
+int run(void) {
   int status = 0;
 
   // exit() handling params
@@ -19,68 +18,80 @@ int run() {
   if (!jmp_rval) {
     readEventData("infra_events_simple.in", 1);
   }
-  test_assert(jmp_rval==0);
+  test_assert(jmp_rval == 0);
   status |= !exit_result;
-  if (status) {printf("FAIL with infra_events_simple.in");}
+  if (status) {
+    printf("FAIL with infra_events_simple.in");
+  }
 
   // Remaining tests should exit()
   should_exit = 1;
 
   // First test
-  exit_result = 1; // reset for next test
+  exit_result = 1;  // reset for next test
   expected_code = EXIT_CODE_UNKNOWN_EVENT_TYPE_OR_PARAM;
   jmp_rval = setjmp(jump_env);
   if (!jmp_rval) {
     readEventData("infra_events_unknown.in", 1);
   }
-  test_assert(jmp_rval==1);
+  test_assert(jmp_rval == 1);
   status |= !exit_result;
-  if (!exit_result) {printf("FAIL with infra_events_unknown.in\n");}
+  if (!exit_result) {
+    printf("FAIL with infra_events_unknown.in\n");
+  }
 
   // Second test
-  exit_result = 1; // reset for next test
+  exit_result = 1;  // reset for next test
   expected_code = EXIT_CODE_INPUT_FILE_ERROR;
   jmp_rval = setjmp(jump_env);
   if (!jmp_rval) {
     readEventData("infra_events_loc_ooo.in", 1);
   }
-  test_assert(jmp_rval==1);
+  test_assert(jmp_rval == 1);
   status |= !exit_result;
-  if (!exit_result) {printf("FAIL with infra_events_loc_ooo\n");}
+  if (!exit_result) {
+    printf("FAIL with infra_events_loc_ooo\n");
+  }
 
   // Third test
-  exit_result = 1; // reset for next test
+  exit_result = 1;  // reset for next test
   expected_code = EXIT_CODE_INPUT_FILE_ERROR;
   jmp_rval = setjmp(jump_env);
   if (!jmp_rval) {
     readEventData("infra_events_date_ooo.in", 1);
   }
-  test_assert(jmp_rval==1);
+  test_assert(jmp_rval == 1);
   status |= !exit_result;
-  if (!exit_result) {printf("FAIL with infra_events_date_ooo.in\n");}
+  if (!exit_result) {
+    printf("FAIL with infra_events_date_ooo.in\n");
+  }
 
   // Bad data tests - NAs in various places
   // Year NA, first line
-  exit_result = 1; // reset for next test
+  exit_result = 1;  // reset for next test
   expected_code = EXIT_CODE_INPUT_FILE_ERROR;
   jmp_rval = setjmp(jump_env);
   if (!jmp_rval) {
     readEventData("infra_events_bad_first.in", 1);
   }
-  test_assert(jmp_rval==1);
+  test_assert(jmp_rval == 1);
   status |= !exit_result;
-  if (!exit_result) {printf("FAIL with infra_events_bad_first.in\n");}
+  if (!exit_result) {
+    printf("FAIL with infra_events_bad_first.in\n");
+  }
 
   // NA in a till event
-  exit_result = 1; // reset for next test
+  exit_result = 1;  // reset for next test
   expected_code = EXIT_CODE_INPUT_FILE_ERROR;
   jmp_rval = setjmp(jump_env);
   if (!jmp_rval) {
     readEventData("infra_events_bad_till.in", 1);
   }
-  test_assert(jmp_rval==1);
+  test_assert(jmp_rval == 1);
   status |= !exit_result;
-  if (!exit_result) {printf("FAIL with infra_events_bad_till.in\n");}
+  if (!exit_result) {
+    printf("FAIL with infra_events_bad_till.in\n");
+  }
 
   // Allow a real exit, not that this is really needed
   really_exit = 1;
@@ -88,7 +99,7 @@ int run() {
   return status;
 }
 
-int main() {
+int main(void) {
   int status;
 
   printf("Starting testEventInfraNeg:run()\n");


### PR DESCRIPTION
This PR changes `readEventData` to allow the events file to be empty or nonexistent, and treat it as "no events specified", even when `EVENT_HANDLER` is on.