### PR TITLE
Irrigation event format change for consistency

### DIFF
--- a/src/sipnet/sipnet.c
+++ b/src/sipnet/sipnet.c
@@ -2572,25 +2572,25 @@ void processEvents(void) {
       case IRRIGATION: {
         const IrrigationParams *irrParams = locEvent->eventParams;
         const double amount = irrParams->amountAdded;
+        double soilAmount, evapAmount;
         if (irrParams->method == CANOPY) {
           // Part of the irrigation evaporates, and the rest makes it to the
-          // soil
-          // Evaporated fraction
-          const double evapAmount = params.immedEvapFrac * amount;
-          fluxes.immedEvap += evapAmount;
-          // Remainder goes to the soil
-          const double soilAmount = amount - evapAmount;
-          envi.soilWater += soilAmount;
-          writeEventOut(eventOutFile, locEvent, 2, "fluxes.immedEvap",
-                        evapAmount, "envi.soilWater", soilAmount);
+          // soil. Evaporated fraction:
+          evapAmount = params.immedEvapFrac * amount;
+          // Soil fraction:
+          soilAmount = amount - evapAmount;
         } else if (irrParams->method == SOIL) {
           // All goes to the soil
-          envi.soilWater += amount;
-          writeEventOut(eventOutFile, locEvent, 1, "envi.soilWater", amount);
+          evapAmount = 0.0;
+          soilAmount = amount;
         } else {
           printf("Unknown irrigation method type: %d\n", irrParams->method);
           exit(EXIT_CODE_UNKNOWN_EVENT_TYPE_OR_PARAM);
         }
+        fluxes.immedEvap += evapAmount;
+        envi.soilWater += soilAmount;
+        writeEventOut(eventOutFile, locEvent, 2, "envi.soilWater", soilAmount,
+                      "fluxes.immedEvap", evapAmount);
       } break;
       case PLANTING: {
         const PlantingParams *plantParams = locEvent->eventParams;

--- a/tests/sipnet/test_events_infrastructure/events_output_header.out
+++ b/tests/sipnet/test_events_infrastructure/events_output_header.out
@@ -1,7 +1,7 @@
 loc  year  day  type     param_name=delta[,param_name=delta,...]
 0    2024   65  plant    envi.plantLeafC=3.00,envi.plantWoodC=4.00,envi.fineRootC=5.00,envi.coarseRootC=6.00
-0    2024   70  irrig    envi.soilWater=5.00
+0    2024   70  irrig    envi.soilWater=5.00,fluxes.immedEvap=0.00
 0    2024  200  harv     env.litter=5.46,envi.plantLeafC=-5.93,envi.plantWoodC=-4.75,envi.fineRootC=-3.73,envi.coarseRootC=-3.89
 1    2024   65  plant    envi.plantLeafC=3.00,envi.plantWoodC=5.00,envi.fineRootC=7.00,envi.coarseRootC=9.00
-1    2024   70  irrig    fluxes.immedEvap=2.50,envi.soilWater=2.50
+1    2024   70  irrig    envi.soilWater=2.50,fluxes.immedEvap=2.50
 1    2024  200  harv     env.litter=4.25,envi.plantLeafC=-1.39,envi.plantWoodC=-1.63,envi.fineRootC=-2.52,envi.coarseRootC=-2.97

--- a/tests/sipnet/test_events_infrastructure/events_output_no_header.out
+++ b/tests/sipnet/test_events_infrastructure/events_output_no_header.out
@@ -1,6 +1,6 @@
 0    2024   65  plant    envi.plantLeafC=10.00,envi.plantWoodC=5.00,envi.fineRootC=4.00,envi.coarseRootC=3.00
-0    2024   70  irrig    envi.soilWater=5.00
+0    2024   70  irrig    envi.soilWater=5.00,fluxes.immedEvap=0.00
 0    2024  200  harv     env.litter=12.40,envi.plantLeafC=-4.80,envi.plantWoodC=-3.20,envi.fineRootC=-4.80,envi.coarseRootC=-4.80
 1    2024   65  plant    envi.plantLeafC=10.00,envi.plantWoodC=5.00,envi.fineRootC=4.00,envi.coarseRootC=3.00
-1    2024   70  irrig    fluxes.immedEvap=2.50,envi.soilWater=2.50
+1    2024   70  irrig    envi.soilWater=2.50,fluxes.immedEvap=2.50
 1    2024  200  harv     env.litter=12.14,envi.plantLeafC=-10.32,envi.plantWoodC=-5.88,envi.fineRootC=-2.88,envi.coarseRootC=-2.48


### PR DESCRIPTION
Just a quicky PR, which:

* Updates format of irrigation events in `events.out` for consistency regardless of soil vs. canopy irrigation
