### PR TITLE
Add doc for mkdocs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -68,6 +68,40 @@ What goes in **docs/*md**:
 - User guides and tutorials.
 - Documentation of equations, theoretical basis, and parameters.
 
+### Building the Documentation with `mkdocs`
+
+Documentation is located at https://pecanproject.github.io/sipnet/, and can be rebuilt using `mkdocs`. A brief summary 
+of use is listed here, or see the Getting Started page for `mkdocs` [here](https://www.mkdocs.org/getting-started/) for
+more information. The third-paRTY theme can be found [here](https://github.com/squidfunk/mkdocs-material).
+```
+pip install mkdocs
+pip install mkdocs-material
+```
+
+MkDocs comes with a built-in dev-server that lets you preview your documentation as you work on it. Make sure you're 
+in the same directory as the mkdocs.yml configuration file, and then start the server by running the mkdocs serve 
+command:
+
+```
+$ mkdocs serve
+INFO    -  Building documentation...
+INFO    -  Cleaning site directory
+INFO    -  Documentation built in 0.22 seconds
+INFO    -  [15:50:43] Watching paths for changes: 'docs', 'mkdocs.yml'
+INFO    -  [15:50:43] Serving on http://127.0.0.1:8000/
+```
+Open up http://127.0.0.1:8000/ in your browser, and you'll see the documentation home page.
+
+The dev-server also supports auto-reloading, and will rebuild your documentation whenever anything in the configuration
+file, documentation directory, or theme directory changes.
+
+If the structure of the documentation has changed (e.g., adding or removing pages), update `mkdocs.yml` in the root 
+directory and issue this command to rebuild:
+
+```
+mkdocs build
+```
+
 ## Compiling SIPNET binaries
 
 SIPNET uses `make` to build the model and documentation. There are also miscellaneous targets for running analysis workflows:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,7 +98,7 @@ The dev-server also supports auto-reloading, and will rebuild your documentation
 file, documentation directory, or theme directory changes.
 
 If the structure of the documentation has changed (e.g., adding or removing pages), update `mkdocs.yml` in the root 
-directory and issue this command to rebuild:
+directory to reflect these changes and issue this command to rebuild:
 
 ```
 mkdocs build

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,7 +97,7 @@ Open up http://127.0.0.1:8000/ in your browser, and you'll see the documentation
 The dev-server also supports auto-reloading, and will rebuild your documentation whenever anything in the configuration
 file, documentation directory, or theme directory changes.
 
-If the structure of the documentation has changed (e.g., adding or removing pages), update `mkdocs.yml` in the root 
+If the structure of the documentation has changed (e.g., adding, moving, removing, or renaming pages), update `mkdocs.yml` in the root 
 directory to reflect these changes and issue this command to rebuild:
 
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -72,11 +72,13 @@ What goes in **docs/*md**:
 
 Documentation is located at https://pecanproject.github.io/sipnet/, and can be rebuilt using `mkdocs`. A brief summary 
 of use is listed here, or see the Getting Started page for `mkdocs` [here](https://www.mkdocs.org/getting-started/) for
-more information. The third-paRTY theme can be found [here](https://github.com/squidfunk/mkdocs-material).
+more information. 
+
+Issue the following command to install `mkdocs` and the third-party extensions usedin SIPNET:
 ```
-pip install mkdocs
-pip install mkdocs-material
+pip install mkdocs mkdocs-material pymdown-extensions
 ```
+The `material` theme can be found [here](https://github.com/squidfunk/mkdocs-material).
 
 MkDocs comes with a built-in dev-server that lets you preview your documentation as you work on it. Make sure you're 
 in the same directory as the mkdocs.yml configuration file, and then start the server by running the mkdocs serve 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ runs.
 
 ## Documentation
 
-Documentation for SIPNET is located [here](https://pecanproject.github.io/sipnet/), which is built using `mkdocs`. See 
+Documentation for SIPNET is published at [pecanproject.github.io/sipnet](https://pecanproject.github.io/sipnet/), which is built using `mkdocs`. See 
 the [Documentation section](CONTRIBUTING.md#documentation) in the CONTRIBUTING page for more information.
 
 ## Roadmap or Changelog section?

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # SIPNET
 
-
-
-SIPNET (Simplified Photosynthesis and Evapotranspiration Model) is an ecosystem model designed to efficiently simulate carbon and water dynamics. Originally developed for assimilation of eddy covariance flux data in forest ecosystems, current development is focused on representing carbon balance and GHG fluxes and agricultural management practices.
+SIPNET (Simplified Photosynthesis and Evapotranspiration Model) is an ecosystem model designed to efficiently simulate
+carbon and water dynamics. Originally developed for assimilation of eddy covariance flux data in forest ecosystems, 
+current development is focused on representing carbon balance and GHG fluxes and agricultural management practices.
 
 ## Getting Started
 
@@ -32,7 +32,8 @@ runs.
 
 ## Documentation
 
-[Describe building the doxygen documentation and what it contains]
+Documentation for SIPNET is located [here](https://pecanproject.github.io/sipnet/), which is built using `mkdocs`. See 
+the [Documentation section](CONTRIBUTING.md#documentation) in the CONTRIBUTING page for more information.
 
 ## Roadmap or Changelog section?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,8 @@ runs.
 ## Documentation
 
 Documentation for SIPNET is published at [pecanproject.github.io/sipnet](https://pecanproject.github.io/sipnet/), which is built using `mkdocs`. See 
-the [Documentation section](CONTRIBUTING.md#documentation) in the CONTRIBUTING page for more information.
+the [Documentation section](CONTRIBUTING.md#documentation) in the CONTRIBUTING page for more information
+about how to write and compile the documentation.
 
 ## Roadmap or Changelog section?
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -43,7 +43,7 @@ Numbered items are cross-referenced with original documentation.
       - [Tillage Events](#tillage-events)
       - [Planting Events](#planting-events)
       - [Harvest Events](#harvest-events)
-      - [Example of events file:](#example-of-events-file)
+      - [Example of events file:](#example-of-eventsin-file)
   - [Outputs](#outputs)
 
 ## Notation


### PR DESCRIPTION
Quickie PR to add some info about using `mkdocs` for SIPNET.