### PR TITLE
SIP93 Warn instead of error for unknown params

### DIFF
--- a/src/common/namelistInput.c
+++ b/src/common/namelistInput.c
@@ -154,10 +154,9 @@ void readNamelistInputs(NamelistInputs *namelistInputs, const char *fileName) {
 
       namelistInputItem = locateNamelistInputItem(namelistInputs, inputName);
       if (namelistInputItem == NULL) {
-        printf("ERROR in readNamelistInputs: Read unexpected input item: %s\n",
-               inputName);
-        printf("Please fix %s and re-run\n", fileName);
-        exit(1);
+        printf("WARNING: ignoring unknown parameter %s in %s\n", inputName,
+               fileName);
+        continue;
       }
       // otherwise, we have found the item with this name
 


### PR DESCRIPTION
This PR changes the error when encountering an unknown param in `sipnet.in` into a warning, and ignores that param.