### PR TITLE
Add edit pencil to docs and change color from indigo to green

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,12 +16,24 @@ nav:
 
 theme:
   name: material
+  custom_dir: docs/overrides
+  features:
+    - content.action.edit
+    - content.action.view
+    - navigation.top
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
 markdown_extensions:
   - pymdownx.arithmatex:
       generic: true  
   - toc:
       permalink: true
   
+
+extra_css:
+  - stylesheets/extra.css
 
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,15 +16,15 @@ nav:
 
 theme:
   name: material
-  custom_dir: docs/overrides
   features:
     - content.action.edit
-    - content.action.view
-    - navigation.top
+  icon:
+    edit: material/pencil 
   palette:
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: green
+      accent: light green
+        
 markdown_extensions:
   - pymdownx.arithmatex:
       generic: true  
@@ -32,14 +32,9 @@ markdown_extensions:
       permalink: true
   
 
-extra_css:
-  - stylesheets/extra.css
-
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   
-
-
 extra:
   arithmatex:
     inline_syntax: ['\\(', '\\)']


### PR DESCRIPTION
PR #97 from a few days ago was insufficient to add edit pencil to the page b/c we aren't using default theme. 


now, see pencil:

![image](https://github.com/user-attachments/assets/2ea18a50-27e8-44b1-9c31-b08e1977567a)
