### PR TITLE
report commit in version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC=gcc
 LD=gcc
 AR=ar -rs
-CFLAGS=-Wall -Werror -g -Isrc -Wno-c2x-extensions
+CFLAGS=-Wall -Werror -g -Isrc -Wno-c2x-extensions -DGIT_HASH='$(GIT_HASH)'
 LIBLINKS=-lm
 LIB_DIR=./libs
 LDFLAGS=-L$(LIB_DIR)
@@ -40,6 +40,10 @@ DOXYGEN_LATEX_DIR = docs/latex
 # the make command, with no arguments, should not build everything in this complex
 # environment
 .DEFAULT_GOAL := sipnet
+
+# Look up what Git revision we're building from
+# We use this below to compile the hash into the binary for ease of debugging
+GIT_HASH := $(shell git rev-parse --short=10 HEAD; git diff-index --quiet HEAD || echo " plus uncommitted changes")
 
 # the main executables - the original 'all' target
 exec: sipnet transpose subsetData

--- a/src/sipnet/version.h
+++ b/src/sipnet/version.h
@@ -1,6 +1,15 @@
 #ifndef SIPNET_VERSION_H
 #define SIPNET_VERSION_H
 
-#define VERSION_STRING "2.0.0"
+#define NUMERIC_VERSION "2.0.0"
+
+// To enable, compile with `-DGIT_HASH="<your revision here>"`
+#ifdef GIT_HASH
+#define str(x) #x
+#define xstr(x) str(x)  // bah, macro string expansion rules
+#define VERSION_STRING NUMERIC_VERSION " (" xstr(GIT_HASH) ")"
+#else
+#define VERSION_STRING NUMERIC_VERSION
+#endif  // GIT_HASH
 
 #endif  // SIPNET_VERSION_H


### PR DESCRIPTION
As discussed live a while ago (but apparently never filed as an issue): Adds the current Git hash to the version reported via `-v`/`--version`.

Before:
```
$ ./sipnet -v      
SIPNET version 2.0.0
```

After:
```
$ ./sipnet -v      
SIPNET version 2.0.0 (2c73bd231f)
```

And if I get ahead of myself and start building uncommitted test code:
```
$ ./sipnet -v
SIPNET version 2.0.0 (2c73bd231f plus uncommitted changes)
```


@Alomir My understanding of macro expansion rounds off to zero, so please call me on anything that needs it / suggest improvements freely.