### PR TITLE
code block formatting in documentation and enable copy button

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ current development is focused on representing carbon balance and GHG fluxes and
 2. Build the SIPNET executable:
    ```bash
     make
-    ```
+   ```
 3. Run a test simulation:
    ```bash
    ./src/sipnet -i tests/smoke/sipnet.in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   name: material
   features:
     - content.action.edit
+    - content.code.copy
   icon:
     edit: material/pencil
   palette:
@@ -32,6 +33,8 @@ markdown_extensions:
       generic: true
   - toc:
       permalink: true
+  - pymdownx.superfences
+
 
 
 extra_javascript:


### PR DESCRIPTION
previously code blocks are rendering like this:

<img width="874" height="274" alt="Screenshot from 2025-07-12 18-15-59" src="https://github.com/user-attachments/assets/3b384768-5a76-4b4e-98c4-f6f7ab8ae75b" />

After adding the extensions and enabling the copy button for code blocks, they now render like this:

<img width="861" height="586" alt="Screenshot from 2025-07-12 18-12-38" src="https://github.com/user-attachments/assets/92af364e-9ae5-4cc4-b6d1-9d4792e5e942" />
