### PR TITLE
SIP165 Fix out-of-order error message

### DIFF
--- a/src/sipnet/events.c
+++ b/src/sipnet/events.c
@@ -238,8 +238,8 @@ EventNode *readEventData(char *eventFile) {
     if ((year < currYear) || ((year == currYear) && (day < currDay))) {
       // clang-format off
       logError("reading event file: last event was at (%d, %d), next event is "
-               "at (%d, %d)\n", currDay, year, day);
-      logError("event records must be in time-ascending order\n", currYear);
+               "at (%d, %d)\n", currYear, currDay, year, day);
+      logError("event records must be in time-ascending order\n");
       // clang-format on
       exit(EXIT_CODE_INPUT_FILE_ERROR);
     }


### PR DESCRIPTION
Fixes #165 

Simple fix for this. I wish CLion could give better diagnostics for wrapped-printf functions, but it is what it is.
