### PR TITLE
Require PR approval by specific people

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # All files in the repository must be reviewed by one of these users
-*   @Alomir @dlebauer @Dietze
+*   @Alomir @dlebauer @mdietze @infotroph @mswilburn 


### PR DESCRIPTION
Now that we are getting more external contributors we can require approvals by specific people using this codeowners file.

Before or after merging we should set "Require review from Code Owners" on this page https://github.com/PecanProject/sipnet/settings/rules/1432057