### PR TITLE
`arch` -> `uname -m` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ $(SIPNET_LIB): $(SIPNET_OFILES)
 GCC_VERSION = $(shell $(CC) --version)
 info:
 	@echo "System info"
-	@echo "ARCH: $(shell arch)"
+	@echo "ARCH: $(shell uname -m)"
 	@echo "CC: $(GCC_VERSION)"
 	@echo ""
 


### PR DESCRIPTION
## Summary

Minor thing, but `arch` is less likely to be present on a system than `uname -m` (case in point: It was missing in my WSL2 Arch Linux install). I think they return basically the same information.

## How to test

Steps to reproduce and verify the change locally:

```bash
make sipnet
```

## Related issues

None

## Checklist

- [ ] Tests added for new features
- [ ] Documentation updated (if applicable)
- [ ] `docs/CHANGELOG.md` updated with noteworthy changes
- [ ] Code formatted with `clang-format` (run `git clang-format` if needed)
- [ ] Requested review from at least one CODEOWNER

**For model structure changes:**
- [ ] Removed `\fraktur` font formatting from `docs/model-structure.md` for implemented features

---

**Note**: See [CONTRIBUTING.md](../docs/CONTRIBUTING.md) for additional guidance. This repository uses automated formatting checks; if the pre-commit hook blocks your commit, run `git clang-format` to format staged changes.
