### PR TITLE
Bug:Fix bitwise AND typo in sipnet.c

### DIFF
--- a/src/sipnet/sipnet.c
+++ b/src/sipnet/sipnet.c
@@ -1269,7 +1269,7 @@ double calcRootAndWoodFluxes(void) {
     fluxes.woodCreation = 0;
   }
 
-  if ((gppSoil > 0) & (envi.fineRootC > 0)) {
+  if ((gppSoil > 0) && (envi.fineRootC > 0)) {
     // :: from [3], eq (5)
     coarseExudate = params.coarseRootExudation * gppSoil;
     fineExudate = params.fineRootExudation * gppSoil;


### PR DESCRIPTION
<!-- Please fill out the sections below to help reviewers. -->

## Summary

- **Motivation**: The current logic for calcRootAndWoodFluxes() has a bug where it uses bitwise operation(&) for boolean comparison instead of (&&).
- **What**: Added && instead of & to add boolean logic.

## How to test

Steps to reproduce and verify the change locally:

```bash
make
cd tests/smoke/<new-or-updated-test> ../../sipnet -i sipnet.in
```

## Related issues

- Fixes #<issue> (or "Relates to #N" if this is not a resolution of that ticket)

## Checklist

- [ ] Tests added for new features
- [ ] Documentation updated (if applicable)
- [ ] `docs/CHANGELOG.md` updated with noteworthy changes
- [x] Code formatted with `clang-format` (run `git clang-format` if needed)
- [x] Requested review from at least one CODEOWNER

**For model structure changes:**
- [ ] Removed `\fraktur` font formatting from `docs/model-structure.md` for implemented features

---

**Note**: See [CONTRIBUTING.md](../docs/CONTRIBUTING.md) for additional guidance. This repository uses automated formatting checks; if the pre-commit hook blocks your commit, run `git clang-format` to format staged changes.
