### PR TITLE
Document moisture clipping behavior and add boundary tests

### DIFF
--- a/docs/model-structure.md
+++ b/docs/model-structure.md
@@ -886,6 +886,10 @@ Where
 - $W_{\text{soil}}$: Soil water content
 - $W_{\text{WHC}}$: Soil water holding capacity
 
+For moisture *dependency functions* (heterotrophic respiration, volatilization, and methanogenesis), SIPNET uses
+$\mathrm{clip}(f_{\text{WHC}},0,1)$ internally. This prevents supersaturated water states from pushing moisture
+response multipliers above their intended maxima.
+
 #### Water Stress Factor
 
 \begin{equation}
@@ -931,7 +935,8 @@ D_{\text{water},R_H} =
 \end{equation}
 
 where $f_{\text{WHC}} = W_{\text{soil}} / W_{\text{WHC}}$ is the fraction of soil water holding capacity (soil water 
-divided by WHC), and $b$ is the soil respiration moisture effect exponent.
+divided by WHC), and $b$ is the soil respiration moisture effect exponent. In implementation, this term is evaluated as
+$\left(\mathrm{clip}(f_{\text{WHC}},0,1)\right)^b$ when moisture dependency is active.
 
 If the command-line option `ANAEROBIC` is on, the dependency is represented as a partition 
 between aerobic and anaerobic pathways:

--- a/docs/user-guide/model-outputs.md
+++ b/docs/user-guide/model-outputs.md
@@ -44,8 +44,8 @@ The `sipnet.out` file contains a time series of state variables and fluxes from 
 | 27  | $F^C_{\text{CH}_4}$  | fluxesch4           | Methane Flux                   | g C/m$^2$ / timestep |
 -->
 
-[^1]: Mean soilWetnessFrac (ratio of soil water / water holding capacity) calculated as average between previous and current time step. Reported for diagnostics; internal 
-calculations of moisture effects use the soilWetnessFrac from the current time step. 
+[^1]: Mean soilWetnessFrac (ratio of soil water / water holding capacity) calculated as average between previous and current time step. Reported for diagnostics only.
+Internal moisture dependency functions use instantaneous $W_{soil}/W_{WHC}$ (not this average), and clip that ratio to [0,1] where those dependency functions are defined.
 
 An example output file can be found in [tests/smoke/sipnet.out](https://github.com/PecanProject/sipnet/blob/master/tests/smoke/niwot/sipnet.out).
 

--- a/src/sipnet/sipnet.c
+++ b/src/sipnet/sipnet.c
@@ -1070,6 +1070,10 @@ void ensureAllocation(void) {
 }
 
 double getClippedWaterFrac(double water, double whc) {
+  // Keep moisture dependency terms bounded in [0, 1]. In configurations with
+  // WATER_HRESP=1 and ANAEROBIC=0 (e.g., russell_1 smoke test), this prevents
+  // super-saturated soil water (water > whc) from boosting respiration above
+  // the full-wet response.
   return fmin(fmax(water / whc, 0.0), 1.0);
 }
 

--- a/tests/sipnet/test_modeling/testDependencyFunctions.c
+++ b/tests/sipnet/test_modeling/testDependencyFunctions.c
@@ -114,6 +114,15 @@ int runTests() {
   climate->tsoil = -10.0;
   status |= checkRespMoistEffect(1);
 
+  // Moisture effect clipping in non-anaerobic mode
+  initTestState();
+  envi.soilWater = 12.0;
+  // f_whc clips to 1
+  status |= checkRespMoistEffect(1.0);
+  envi.soilWater = -1.0;
+  // f_whc clips to 0
+  status |= checkRespMoistEffect(0.0);
+
   // Moisture effect, with new dependency mode
   initTestState();
   ctx.anaerobic = 1;


### PR DESCRIPTION
### Motivation
- Clarify where the model bounds soil moisture for moisture-dependency functions to resolve ambiguity about why some smoke tests showed `soilWetnessFrac > 1` while dependency terms do not exceed 1.
- Provide automated test coverage that validates the intended clipping behavior at the aerobic (non-anaerobic) boundaries so the intent is captured in tests as well as docs.

### Description
- Updated `docs/model-structure.md` to state that moisture dependency functions use `clip(f_WH C, 0, 1)` internally and that the respiration power-law is evaluated as `clip(f_WH C,0,1)^b` when dependencies are active. 
- Updated `docs/user-guide/model-outputs.md` to clarify that `soilWetnessFrac` in outputs is a timestep average diagnostic and that internal dependency calculations use the instantaneous `W_soil/W_WHC` (clipped to `[0,1]`).
- Added unit test cases to `tests/sipnet/test_modeling/testDependencyFunctions.c` that exercise non-anaerobic clipping bounds (`soilWater > WHC` and `soilWater < 0`) to lock the intended behavior.
- Left model runtime logic unchanged; `getClippedWaterFrac()` continues to be used in moisture dependency functions and is not applied to soil evaporation (there is an existing `TODO` for that spot).

### Testing
- Built the binary with `make sipnet` and the build succeeded. 
- Ran the automated unit tests with `./tools/run_unit_tests.sh` and all tests (including the updated `testDependencyFunctions`) passed. 
- Ran a smoke-output scan (Python script) across smoke test outputs to confirm `soilWetnessFrac` diagnostics exceed 1.0 for the russell tests but not for niwot, which explains prior differences observed; this check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69988c1fd584832b9ebbad33ba9a2c32)