### PR TITLE
[#291][#292] Fix memory safety vulnerabilities in Restart parser

### DIFF
--- a/src/sipnet/restart.c
+++ b/src/sipnet/restart.c
@@ -321,7 +321,7 @@ validateCheckpointBoundaryForLoad(const char *restartIn,
 // Assumes input char *dest is BUILD_INFO_BUFFER_SIZE in length
 static void sanitizeBuildInfo(char *dest, const char *src) {
   size_t ind = 0;
-  while (src[ind] != '\0' && ind < (BUILD_INFO_BUFFER_SIZE - 1)) {
+  while (ind < (BUILD_INFO_BUFFER_SIZE - 1) && src[ind] != '\0') {
     char c = src[ind];
     if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
       dest[ind] = '_';
@@ -654,6 +654,14 @@ static void readRestartState(const char *restartIn, RestartState *state,
   }
 
   fclose(in);
+
+  // Validate that the checkpoint file did not attempt to resize the MeanTracker
+  if (meanNPP->length != meanLength) {
+    logError("Restart schema mismatch in %s: mean.npp.length (%d) does not "
+             "match the compiled model length (%d)\n",
+             restartIn, meanNPP->length, meanLength);
+    exit(EXIT_CODE_BAD_RESTART_PARAMETER);
+  }
 
   verifySeenBatch(state->metaPF, NUM_META_FIELDS, restartIn);
   verifySeenBatch(state->schemaPF, NUM_SCHEMA_FIELDS, restartIn);


### PR DESCRIPTION
<!-- Please fill out the sections below to help reviewers. -->

## Summary

- **What**: Fixed a heap buffer overflow vulnerability in src/sipnet/restart.c (`readRestartState`) by validating the parsed mean.npp.length against the model's runtime-allocated length.
Fixed a read-before-check out-of-bounds array access in `sanitizeBuildInfo` by swapping the condition order in the while loop.

- **Motivation**: To ensure strict memory safety when parsing external ASCII checkpoint files. The previous implementation blindly trusted the file's mean.npp.length, which allowed malicious or accidentally malformed files to force SIPNET to write past the bounds of the MeanTracker heap arrays, causing segmentation faults or silent memory corruption.

## How was this change tested?
Ran cppcheck which successfully cleared the array boundary warnings in sanitizeBuildInfo.

Compiled the model locally on Apple Silicon using make CFLAGS="-g -fsanitize=address -O1" LDFLAGS="-fsanitize=address". Fed the model a "poisoned" checkpoint file (mean.npp.length 9999).

Before fix: Triggered a fatal heap-buffer-overflow write violation.
After fix: Safely caught the mismatch and exited gracefully with EXIT_CODE_BAD_RESTART_PARAMETER

If changes are needed for any `sipnet.out` files in the `test/smoke` subdirectories, then include output from
`tools/smoke_check.py` by running the commands below and pasting the output at the end of this PR. Note that 
this must be run BEFORE submitting changes to any `sipnet.out` files.
```bash
make smoke
python tools/smoke_check.py run verbose <list tests/smoke subdirectories with changed outputs>
```
Run `python tools/smoke_check.py help` for more info.

## Reproduction steps

To reproduce the Heap Overflow (Issue #291):
1.Generate a valid sipnet checkpoint.
2.Manually edit the file to read mean.npp.length 9999 and mean.npp.start 9000.
3.Run the program.

To reproduce the Logic Error (Issue #292):
Run cppcheck --enable=all src/sipnet/restart.c and observe the [arrayIndexThenCheck] warning at line 32

## Related issues

- Fixes #291 and #292 

## Checklist

- [x] Related issues are listed above. [PRs without an approved, related issue may not get reviewed](docs/CONTRIBUTING.md#propose-and-receive-feedback).
- [x] PR title has the issue number in it ("[#<number>] \<concise description of proposed change>")
- [ ] Tests added/updated for new features (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] `docs/CHANGELOG.md` updated with noteworthy changes
- [x] Code formatted with `clang-format` (run `git clang-format` if needed)

---

**Note**: See [CONTRIBUTING.md](../docs/CONTRIBUTING.md) for additional guidance. This repository uses automated formatting checks; if the pre-commit hook blocks your commit, run `git clang-format` to format staged changes.
