### PR TITLE
[#294]Update .gitignore to exclude generated test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ cmake-build-debug-gcc/
 *~
 *.tmp
 /tmp/
+
+# Exclude generated restart and infrastructure test artifacts
+tests/sipnet/test_restart_infrastructure/*.out
+tests/sipnet/test_restart_infrastructure/*.in
+tests/sipnet/test_restart_infrastructure/*.clim
+tests/sipnet/test_restart_infrastructure/*.param
+tests/sipnet/test_restart_infrastructure/bad_code/*
+tests/sipnet/test_sipnet_infrastructure/format_check.out


### PR DESCRIPTION
## Summary

- **What**: Added the missing files and folder `test_restart_infrastructure` and `test_sipnet_infrastructure` suites to the ignore list at the bottom of `.gitignore`.
- **Motivation**: Running `make test` was polluting the workspace with 16+ untracked files (e.g., `continuous.out`, `restart.clim`, `format_check.out`). Because the project's `.gitignore` explicitly un-ignores `*.out` and `*.clim` files in the test directories to preserve checked-in static fixtures, the new dynamically generated files from the restart tests were being flagged as untracked by Git.Which could cause these to be accidentally pushed to the repo.

## How was this change tested?
1. Ran `make test` locally to generate the artifacts.
2. Ran `git status`.
3. Verified that the working tree remains completely clean and the previously untracked files are now successfully ignored.


## Reproduction steps
1. Run `make test`.
2. Run `git status`.
3. Observe that the working directory is clean and no test artifacts are left pending.

## Related issues

- Fixes #294 

## Checklist

- [x] Related issues are listed above. [PRs without an approved, related issue may not get reviewed](docs/CONTRIBUTING.md#propose-and-receive-feedback).
- [x] PR title has the issue number in it ("[#<number>] \<concise description of proposed change>")
- [ ] Tests added/updated for new features (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] `docs/CHANGELOG.md` updated with noteworthy changes
- [ ] Code formatted with `clang-format` (run `git clang-format` if needed)