### PR TITLE
SIP300 Reduce (some) logWarnings to logInfos

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,6 +57,8 @@ sections to include in release notes:
 
 ### Changed
 
+- Reduced many `logWarning` messages to `logInfo` (#302)
+
 ### Removed
 - 'Notes' line at top of `sipnet.out` header (#267)
 

--- a/src/common/modelParams.c
+++ b/src/common/modelParams.c
@@ -55,7 +55,7 @@ void checkAllRead(ModelParams *ModelParams) {
   // Inform if any optional params are not in the file; not an error, just a
   // note, and just one line instead of one for each
   if ((missingOptParam) && (!ctx.quiet)) {
-    logWarning("optional params not specified in input file:");
+    logInfo("optional params not specified in input file:");
     for (i = 0; i < ModelParams->numParams; i++) {
       param = &(ModelParams->params[i]);
       if ((!param->isRead) && (param->isRequired == 0)) {
@@ -129,9 +129,9 @@ void initializeOneModelParam(ModelParams *modelParams, char *name,
 void checkParamFormat(char *line, const char *sep) {
   int numParams = countFields(line, sep);
   if (numParams > 2) {
-    logWarning("extra columns in .param file are being ignored (found %d "
-               "columns)\n",
-               numParams);
+    logInfo("extra columns in .param file are being ignored (found %d "
+            "columns)\n",
+            numParams);
   }
 }
 
@@ -217,7 +217,7 @@ void readModelParams(ModelParams *modelParams, FILE *paramFile) {
 
   // Warn if unknown params were found
   if (hasUnknownParams) {
-    logWarning("Unknown param(s) found (and ignored): %s\n", unknownParams);
+    logInfo("Unknown param(s) found (and ignored): %s\n", unknownParams);
   }
 
   // check for error in reading:

--- a/src/common/modelParams.c
+++ b/src/common/modelParams.c
@@ -32,8 +32,7 @@ void setAll(double *array, int length, double value) {
 
 // Checks to make sure that all parameters with isRequired=true have been read
 // If not, kills program
-// Writes out names of all parameters that weren't read (even if not required,
-// as a warning message)
+// Writes out names of all parameters that weren't read (even if not required)
 // Also prints out a list of obsolete params that were read
 void checkAllRead(ModelParams *ModelParams) {
   int i, okay, missingOptParam = 0;

--- a/src/sipnet/events.c
+++ b/src/sipnet/events.c
@@ -102,8 +102,8 @@ EventNode *createEventNode(int year, int day, int eventType,
       newEvent->eventParams = fParams;
 
       if (!ctx.nitrogenCycle && (orgN > 0.0 || minN > 0.0) && !nitrogenWarned) {
-        logWarning("Fertilization nitrogen quantities are being ignored since "
-                   "nitrogen cycle modeling is off\n");
+        logInfo("Fertilization nitrogen quantities are being ignored since "
+                "nitrogen cycle modeling is off\n");
         nitrogenWarned = 1;
       }
     } break;

--- a/src/sipnet/frontend.c
+++ b/src/sipnet/frontend.c
@@ -75,7 +75,7 @@ void readInputFile(void) {
       // Find the metadata so we know what to do with this param
       struct context_metadata *ctx_meta = getContextMetadata(inputName);
       if (ctx_meta == NULL) {
-        logWarning("ignoring input file parameter %s\n", inputName);
+        logInfo("ignoring input file parameter %s\n", inputName);
         continue;
       }
 

--- a/src/sipnet/restart.c
+++ b/src/sipnet/restart.c
@@ -792,8 +792,8 @@ static void validateRestartModelBuild(void) {
   }
 
   if (strcmp(buildInfo, currentBuildInfo) != 0) {
-    logWarning("Restart build info mismatch: checkpoint=%s current=%s\n",
-               buildInfo, currentBuildInfo);
+    logInfo("Restart build info mismatch: checkpoint=%s current=%s\n",
+            buildInfo, currentBuildInfo);
   }
 }
 

--- a/src/sipnet/sipnet.c
+++ b/src/sipnet/sipnet.c
@@ -163,9 +163,9 @@ void readClimData(const char *climFile) {
     case NUM_CLIM_FILE_COLS_LEGACY:
       expectedNumCols = NUM_CLIM_FILE_COLS_LEGACY;
       legacyFormat = 1;
-      logWarning("old climate file format detected (found %d cols); ignoring "
-                 "location and soilWetness columns in %s\n",
-                 numFields, climFile);
+      logInfo("old climate file format detected (found %d cols); ignoring "
+              "location and soilWetness columns in %s\n",
+              numFields, climFile);
       break;
     default:
       // Unrecognized format


### PR DESCRIPTION
## Summary

- **What**: Reduce the log level (warning -> info) for many messages
- **Motivation**: Warning is inaccurate, as these do not indicate problems. Also, it has been noticed that it causes false concerns when running sipnet, specifically new users going through the 'Getting Started' steps.

## How was this change tested?

There are no functional changes, so existing tests passing should be sufficient.

## Related issues

- Fixes #300

## Checklist

- [x] Related issues are listed above. [PRs without an approved, related issue may not get reviewed](docs/CONTRIBUTING.md#propose-and-receive-feedback).
- [x] PR title has the issue number in it ("[#<number>] \<concise description of proposed change>")
- [x] Tests added/updated for new features (if applicable)
- [x] Documentation updated (if applicable)
- [x] `docs/CHANGELOG.md` updated with noteworthy changes
- [x] Code formatted with `clang-format` (run `git clang-format` if needed)

---

**Note**: See [CONTRIBUTING.md](../docs/CONTRIBUTING.md) for additional guidance. This repository uses automated formatting checks; if the pre-commit hook blocks your commit, run `git clang-format` to format staged changes.
