### PR TITLE
Bump numeric version + build tag into -v output

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: "SIPNET: Simple Photosynthesis and Evapotranspiration Model"
-version: 2.0.0
+version: 2.1.0
 abstract: >
   SIPNET (Simple Photosynthesis and Evapotranspiration Model) is a process-based
   ecosystem model designed to simulate carbon and water fluxes and (optionally) agricultural management
@@ -56,7 +56,7 @@ keywords:
 preferred-citation:
   type: software
   title: "SIPNET: Simple Photosynthesis and Evapotranspiration Model"
-  version: 2.0.0
+  version: 2.1.0
   url: https://github.com/PecanProject/sipnet
   authors:
     - family-names: Michael

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DOXYGEN_LATEX_DIR = docs/latex
 
 # Look up what Git revision we're building from
 # We use this below to compile the hash into the binary for ease of debugging
-GIT_HASH := $(shell git rev-parse --short=10 HEAD; git diff-index --quiet HEAD || echo " plus uncommitted changes")
+GIT_HASH := $(shell git describe --tags --abbrev=10 HEAD; git diff-index --quiet HEAD || echo " plus uncommitted changes")
 
 # all does everything build related (but not test)
 all: sipnet document

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = SIPNET
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.0.0
+PROJECT_NUMBER         = 2.1.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/src/sipnet/version.h
+++ b/src/sipnet/version.h
@@ -1,7 +1,7 @@
 #ifndef SIPNET_VERSION_H
 #define SIPNET_VERSION_H
 
-#define NUMERIC_VERSION "2.0.0"
+#define NUMERIC_VERSION "2.1.0"
 
 // To enable, compile with `-DGIT_HASH="<your revision here>"`
 #ifdef GIT_HASH


### PR DESCRIPTION
<!-- Please fill out the sections below to help reviewers. -->

## Summary

Calling `sipnet -v` on the tagged v2.1.0 Sipnet still reports "SIPNET version 2.0.0 (651d66d201)", suggesting it's time to bump the value of NUMERIC_VERSION in version.h.

We can also get a touch more automated by using `git describe` to build tag names into the commit summary -- see below. 

## How was this change tested?
`make clean && make && ./sipnet -v`

* Tested locally with and without uncommitted changes and at commits that are and are not identical to known tags
* Verified that today's result is reasonable in a freshly cloned repo where nobody without needing a `git pull --tags`. It'd be worth checking again once HEAD has moved past the tag -- I remember there may be fine print about when tags are and are not fetched by default.

## Reproduction steps

Current version:

```
% git checkout v2.1.0
% make clean && make && ./sipnet -v
# [compilation output snipped]
SIPNET version 2.0.0 (651d66d201)
% git checkout HEAD^ 
% make clean && make && ./sipnet -v
# [compilation output snipped]
SIPNET version 2.0.0 (c44f579a86)
```


After this change (I created a local v2.1.1 tag for illustration):

```
% git checkout v2.1.1-pre
% make clean && make && ./sipnet -v
# [compilation output snipped]
SIPNET version 2.1.0 (2.1.1-pre)
% git checkout HEAD^ 
% make clean && make && ./sipnet -v
# [compilation output snipped]
SIPNET version 2.1.0 (v2.1.0-1-g601265e399)
```

... so now even without any change to the hard-coded "version 2.1.0" we can automatically see which one was compiled exactly from the tag vs which was a plain old branch tip.
