### PR TITLE
Changelog fix: woodCreation double counting reference issue/pr number

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,7 +69,7 @@ sections to include in release notes:
 ### Fixed
 
 - Out of order error message for events (#166)
-- `woodCreation` was being double counted; note that this change will likely require recalibration of SIPNET params (#282)
+- `woodCreation` was being double counted; note that this change will likely require recalibration of SIPNET params (#208, #248)
 
 ### Changed
 


### PR DESCRIPTION
Updated issue references in for woodCreation double counting fix.

```sh
-- `woodCreation` was being double counted;... (#282)
+- `woodCreation` was being double counted;... (#208, #248)
```

Also updated 2.1.0 release notes