### PR TITLE
Fix indentation preventing `\end{equation}` from rendering

### DIFF
--- a/docs/model-structure.md
+++ b/docs/model-structure.md
@@ -149,8 +149,8 @@ Note that $\alpha_i$ are specified input parameters and $\sum_i{\alpha_i} = 1$.
 
 - F^C_{\text{harvest,removed,}i}
 - F^C_{\text{litter,}i}
-  \label{eq:Zobitz_3}
-  \end{equation}
+\label{eq:Zobitz_3}
+\end{equation}
 
 This is equation (3) from Zobitz, et al. (2008), augmented with the harvest and litter terms. Summing over all plant
 pools shows that NPP is partitioned into biomass growth, removed harvest, and litter production.


### PR DESCRIPTION
<!-- Please fill out the sections below to help reviewers. -->

## Summary

- **What**: Just docs
- **Motivation**: Currently one equation is not rendering b/c extra spaces, so renders as:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/219d8abf-a712-45fc-be84-2a73cda65f58" />


## How was this change tested?

🤞🏻 will check built site preview

## Checklist

- [ ] Related issues are listed above. [PRs without an approved, related issue may not get reviewed](docs/CONTRIBUTING.md#propose-and-receive-feedback).
- [ ] PR title has the issue number in it ("[#<number>] \<concise description of proposed change>")
- [ ] Tests added/updated for new features (if applicable)
- [x] Documentation updated (if applicable)
- [ ] `docs/CHANGELOG.md` updated with noteworthy changes
- [ ] Code formatted with `clang-format` (run `git clang-format` if needed)

---

**Note**: See [CONTRIBUTING.md](../docs/CONTRIBUTING.md) for additional guidance. This repository uses automated formatting checks; if the pre-commit hook blocks your commit, run `git clang-format` to format staged changes.
