### PR TITLE
Update model inputs restrictions (tiny docs fix)

### DIFF
--- a/docs/user-guide/model-inputs.md
+++ b/docs/user-guide/model-inputs.md
@@ -248,6 +248,7 @@ Note the following restrictions on these options:
  - `soil-phenol` and `gdd` may not both be turned on
  - `anaerobic` requires `water-hresp`
  - 'nitrogen-cycle' requires both 'litter-pool' and 'anaerobic'
+ - `carbon-saturation` requires `litter-pool`
 
 ### Command Line Arguments
 


### PR DESCRIPTION
Add restriction for 'carbon-saturation' requiring 'litter-pool'.

Docs only; too small to use PR template.