### PR TITLE
[#362] Clean up generated log files in testDebugLogFiles unit test

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,8 @@ sections to include in release notes:
 
 ### Fixed
 
+- Fix testDebugLogFiles unit test leaving untracked log files in workspace after execution (#358)
+
 ### Changed
 
 - Renamed the CLI option `--file-name` to `--file-prefix` for clarity while keeping `--file-name` as a backward-compatible alias (#320)

--- a/tests/sipnet/test_sipnet_infrastructure/testDebugLogFiles.c
+++ b/tests/sipnet/test_sipnet_infrastructure/testDebugLogFiles.c
@@ -133,6 +133,11 @@ int run(void) {
     status = 1;
   }
 
+  if (status == 0) {
+    runShell("cd " TEST_WORK_DIR
+             " && rm -rf debug_logs && rm -f debug_log_test.log");
+  }
+
   return status;
 }
 


### PR DESCRIPTION
<!-- Please fill out the sections below to help reviewers. -->

## Summary

- **What**: Added cleanup step to `testDebugLogFiles.c` to delete the temporary generated log files on successful test completion.
- **Motivation**: Running unit tests currently leaves untracked generated logs (`debug_logs/` and `debug_log_test.log`) in `tests/smoke/russell_1/`, causing the git working tree to become dirty.

## How was this change tested?
Ran `make test` locally, verified that all tests passed, and confirmed that `git status` reports no untracked files afterwards.

## Reproduction steps
1. Run `make test` on master branch -> `git status` shows untracked log files.
2. Apply changes and run `make test` -> `git status` remains clean.

## Related issues

- Fixes #362 

## Checklist

- [x] Related issues are listed above. [PRs without an approved, related issue may not get reviewed](docs/CONTRIBUTING.md#propose-and-receive-feedback).
- [x] PR title has the issue number in it ("[#<number>] \<concise description of proposed change>")
- [x] Tests added/updated for new features (if applicable)
- [x] Documentation updated (if applicable)
- [x] `docs/CHANGELOG.md` updated with noteworthy changes
- [x] Code formatted with `clang-format` (run `git clang-format` if needed)
