### PR TITLE
SIP370 Add guard to check for leach+vol -> negative min N

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ sections to include in release notes:
 - Ability to create derived columns in `sipnet-view` (#355)
 - New `sipnet-debug-view` tool for visualizing SIPNET debug output files (#359)
 - Plant mortality check with event output on occurrence (#359)
+- Guard against negative mineral N due to volatilization and/or leaching (#375)
 
 ### Fixed
 

--- a/src/sipnet/limitations.c
+++ b/src/sipnet/limitations.c
@@ -113,10 +113,26 @@ static void checkNitrogenLimitation(void) {
   }
 }
 
+/**
+ * Check if leaching and volatilization will drive mineral N negative
+ */
+void checkMineralNLimitation(void) {
+  double len = climate->length;
+  double pool = envi.minN + (fluxes.nMin + fluxes.eventMinN) * len;
+  double loss = (fluxes.nLeaching + fluxes.nVolatilization) * len;
+  if (loss > pool) {
+    double reduction = (loss - pool) / loss;
+    fluxes.nLeaching *= reduction;
+    fluxes.nVolatilization *= reduction;
+  }
+}
+
 // See limitations.h
 void checkLimitations(void) {
   // Our only post-flux limitation to check
   if (ctx.nitrogenCycle) {
+    // Call the mineral N check before the general N Limitation check
+    checkMineralNLimitation();
     checkNitrogenLimitation();
   }
 }

--- a/src/sipnet/limitations.c
+++ b/src/sipnet/limitations.c
@@ -116,7 +116,7 @@ static void checkNitrogenLimitation(void) {
 /**
  * Check if leaching and volatilization will drive mineral N negative
  */
-void checkMineralNLimitation(void) {
+static void checkMineralNLimitation(void) {
   double len = climate->length;
   double pool = envi.minN + (fluxes.nMin + fluxes.eventMinN) * len;
   double loss = (fluxes.nLeaching + fluxes.nVolatilization) * len;

--- a/src/sipnet/limitations.c
+++ b/src/sipnet/limitations.c
@@ -120,8 +120,9 @@ void checkMineralNLimitation(void) {
   double len = climate->length;
   double pool = envi.minN + (fluxes.nMin + fluxes.eventMinN) * len;
   double loss = (fluxes.nLeaching + fluxes.nVolatilization) * len;
-  if (loss > pool) {
-    double reduction = (loss - pool) / loss;
+
+  if (loss > TINY && loss > pool) {
+    double reduction = pool / loss;
     fluxes.nLeaching *= reduction;
     fluxes.nVolatilization *= reduction;
   }

--- a/tests/sipnet/test_modeling/testNitrogenCycle.c
+++ b/tests/sipnet/test_modeling/testNitrogenCycle.c
@@ -748,8 +748,11 @@ int testGuardAgainstNegativeMinN(void) {
   logTest("Running testGuardAgainstNegativeMinN\n");
 
   // Case 1: no leaching, as W_soil < WHC, but maxed vol
+  // We'll add some mineralization too, to make sure reduction is correct in
+  // that case
   // Vol
   resetState();
+  fluxes.nMin = 2.0;  // 0.25 extra min N
   envi.minN = 1.0;
   params.fAnoxia = 0.6;
   params.soilWHC = 10.0;
@@ -771,7 +774,8 @@ int testGuardAgainstNegativeMinN(void) {
   status |= checkVolAndLeachingFlux("volatilization", expNVol, expNLeach);
   // Call the limit check should reduce nVol to 8 (enough to just exhaust nMin)
   checkMineralNLimitation();
-  status |= checkVolAndLeachingFlux("volatilization", 8.0, 0.0);
+  expNVol *= 10.0 / expNVol;
+  status |= checkVolAndLeachingFlux("volatilization", expNVol, 0.0);
   // Check that minN is zero at end
   updateNitrogenPools();
   status |= checkMinAndStorageN("volatilization", 0.0, 0.0);

--- a/tests/sipnet/test_modeling/testNitrogenCycle.c
+++ b/tests/sipnet/test_modeling/testNitrogenCycle.c
@@ -725,6 +725,90 @@ int testLeafTurnoverNResorption(void) {
   return status;
 }
 
+int checkVolAndLeachingFlux(const char *prefix, double expNVol,
+                            double expNLeach) {
+  int status = 0;
+  if (!compareDoubles(fluxes.nVolatilization, expNVol)) {
+    status = 1;
+    logTest("[%s] nVolatilization is %8.4f, expected %8.4f\n", prefix,
+            fluxes.nVolatilization, expNVol);
+  }
+  if (!compareDoubles(fluxes.nLeaching, expNLeach)) {
+    status = 1;
+    logTest("[%s] nLeaching is %8.4f, expected %8.4f\n", prefix,
+            fluxes.nLeaching, expNLeach);
+  }
+  return status;
+}
+
+/////
+// Test our guard against vol+leaching driving min N negative
+int testGuardAgainstNegativeMinN(void) {
+  int status = 0;
+  logTest("Running testGuardAgainstNegativeMinN\n");
+
+  // Case 1: no leaching, as W_soil < WHC, but maxed vol
+  // Vol
+  resetState();
+  envi.minN = 1.0;
+  params.fAnoxia = 0.6;
+  params.soilWHC = 10.0;
+  envi.soilWater = 8.0;  // anaerobic index = 0.5, D_water = 1
+  params.soilRespQ10 = 2.5;
+  climate->tsoil = 30.0;  // D_temp = 15.625
+  params.nVolatilizationFrac = 1.0;  // 100% can volatilize / day
+  double expNVol = 1 * 1 * 1 * 15.625;
+
+  // We'll set up the leaching, as we need some values for this
+  // Leaching
+  // nLeaching = 1.0 * 0.8 * 0.5 = 0.4
+  params.nLeachingFrac = 0.5;
+  fluxes.drainage = 0.0;
+  double expNLeach = 0.0;
+
+  calcNVolatilizationFlux();
+  calcNLeachingFlux();
+  status |= checkVolAndLeachingFlux("volatilization", expNVol, expNLeach);
+  // Call the limit check should reduce nVol to 8 (enough to just exhaust nMin)
+  checkMineralNLimitation();
+  status |= checkVolAndLeachingFlux("volatilization", 8.0, 0.0);
+  // Check that minN is zero at end
+  updateNitrogenPools();
+  status |= checkMinAndStorageN("volatilization", 0.0, 0.0);
+
+  // Case 2: Leaching
+  // We'll have a trickle of vol here, plus as much leaching as we can. Need
+  // hot + wet (flooding)
+  resetState();
+  envi.minN = 1.0;
+  // Leaching
+  envi.soilWater = 20.0;
+  fluxes.drainage = 10.0;  // phi = 1.0
+  params.nLeachingFrac = 8.0;  // 100% leached every three hours
+  expNLeach = 1.0 * 1.0 * 8.0;  // 8.0
+  // Vol
+  params.nVolatilizationFrac = 1.0;  // 100% can volatilize / day
+  params.soilRespQ10 = 3;
+  climate->tsoil = 20.0;  // D_temp = 9
+  // D_water = 0.05 now
+  expNVol = 1 * 1 * 0.05 * 9;  // 0.45
+
+  calcNVolatilizationFlux();
+  calcNLeachingFlux();
+  status |= checkVolAndLeachingFlux("leaching", expNVol, expNLeach);
+  // Call the limit check should reduce both to sum to 8
+  double reduction = 8.0 / 8.45;
+  expNVol *= reduction;
+  expNLeach *= reduction;
+  checkMineralNLimitation();
+  status |= checkVolAndLeachingFlux("leaching", expNVol, expNLeach);
+  // Check that minN is zero at end
+  updateNitrogenPools();
+  status |= checkMinAndStorageN("leaching", 0.0, 0.0);
+
+  return status;
+}
+
 int run(void) {
   int status = 0;
 
@@ -740,6 +824,7 @@ int run(void) {
   status |= testUpdateNitrogenPoolsFromStorage();
   status |= testOrganicNWithResorption();
   status |= testLeafTurnoverNResorption();
+  status |= testGuardAgainstNegativeMinN();
 
   return status;
 }

--- a/tests/sipnet/test_modeling/testNitrogenCycle.c
+++ b/tests/sipnet/test_modeling/testNitrogenCycle.c
@@ -772,7 +772,7 @@ int testGuardAgainstNegativeMinN(void) {
   calcNVolatilizationFlux();
   calcNLeachingFlux();
   status |= checkVolAndLeachingFlux("volatilization", expNVol, expNLeach);
-  // Call the limit check should reduce nVol to 8 (enough to just exhaust nMin)
+  // Call the limit check should reduce nVol to 10 (enough to just exhaust nMin)
   checkMineralNLimitation();
   expNVol *= 10.0 / expNVol;
   status |= checkVolAndLeachingFlux("volatilization", expNVol, 0.0);


### PR DESCRIPTION
## Summary

- **What**: Guard against leaching + volatilization causing negative mineral N
- **Motivation**: This is an edge case, but still needs to be addressed

## Details

* Added guard in limitations.c
* Guard function called right before general N limitation check
* Unit test points added

## How was this change tested?
* Test points added for each case of excessive volatilization and leaching
* All other unit tests pass unmodified
* Smoke tests pass unmodified

## Related issues

- Fixes #370 

## Checklist

- [ ] Related issues are listed above. [PRs without an approved, related issue may not get reviewed](docs/CONTRIBUTING.md#propose-and-receive-feedback).
- [ ] PR title has the issue number in it ("[#<number>] \<concise description of proposed change>")
- [ ] Tests added/updated for new features (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] `docs/CHANGELOG.md` updated with noteworthy changes
- [ ] Code formatted with `clang-format` (run `git clang-format` if needed)
