### PR TITLE
[#373] Add repository guard to scheduled link-check workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   link-check:
     runs-on: ubuntu-latest
+    if: github.repository == 'PecanProject/sipnet'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- **What:** Adds `if: github.repository == 'PecanProject/sipnet'` to the `link-check` job in `.github/workflows/link-check.yml`.
- **Motivation:** Prevents the weekly scheduled link-check cron job from running unnecessarily on contributor forks and generating spurious failure notifications.

## How was this change tested?

- Verified YAML syntax and job configuration.
- `pull_request` runs targeting `PecanProject/sipnet` will evaluate to `true` and continue running normally.

## Related issues

- Fixes #373

## Checklist

- [x] Related issues are listed above.
- [x] PR title has the issue number in it (`[#] <concise description of proposed change>`).
- [x] Tests added/updated for new features (not applicable for workflow configuration).
- [x] Documentation updated (not applicable).
- [x] Code formatted with clang-format.
