### PR TITLE
SIP377 Fix calcLeafOnNFromC, allowing negative return values

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,8 @@ sections to include in release notes:
 
 ### Fixed
 
+- Preserve nitrogen balance during leaf-on when leaf C:N exceeds wood C:N (#381)
+
 ### Changed
 
 - Renamed the CLI option `--file-name` to `--file-prefix` for clarity while keeping `--file-name` as a backward-compatible alias (#320)

--- a/src/sipnet/nitrogen.c
+++ b/src/sipnet/nitrogen.c
@@ -84,7 +84,10 @@ static void calcNPoolFluxes(void) {
 
 // see nitrogen.h
 double calcLeafOnNFromC(double leafOnC) {
-  return fmax(0.0, leafOnC / params.leafCN - leafOnC / params.woodCN);
+  // If woodCN is less than leafCN (for whatever reason), this will return
+  // a negative value. This should be treated as N to be resorbed (which will
+  // likely happen automatically in plantStorageN pool updates).
+  return leafOnC / params.leafCN - leafOnC / params.woodCN;
 }
 
 // see nitrogen.h
@@ -112,9 +115,7 @@ double calcPlantAvailableN(void) {
   // step is ok). This is used in the determination of N limitation.
   // Note, though, that we can't really use the incoming N to plantStorageN,
   // as that is not immediately available to offset minN loss.
-  double leafOnCFlux = fluxes.leafOnCreation + fluxes.eventLeafOnCreation;
-  double leafOnNFlux = calcLeafOnNFromC(leafOnCFlux);
-  double unclaimedStorage = envi.plantStorageN - leafOnNFlux * climate->length;
+  double unclaimedStorage = calcUnclaimedStorageN();
   double nonUptakeDelta = calcMinNNonUptakeFluxes() * climate->length;
   return fmax(0.0, envi.minN + unclaimedStorage + nonUptakeDelta);
 }

--- a/src/sipnet/nitrogen.h
+++ b/src/sipnet/nitrogen.h
@@ -6,8 +6,10 @@
 /*!
  * Calculate excess N needed for leaf on events
  *
- * Note: leafOnC can be either a flux or pool measurement; the returned
- * value will match.
+ * The input leafOnC can be either a flux or pool measurement; the returned
+ * value will match. Note that this will return a negative value in the rare
+ * case that params.woodCN < params.leafCN, indicating that some N should be
+ * resorbed.
  */
 double calcLeafOnNFromC(double leafOnC);
 

--- a/tests/sipnet/test_modeling/testBalance.c
+++ b/tests/sipnet/test_modeling/testBalance.c
@@ -91,9 +91,6 @@ int testBalanceLeaf(void) {
   logTest("Starting testBalanceLeaf()\n");
   int status = 0;
 
-  params.leafOnDay = 0;
-  params.leafOffDay = 0;
-
   // Run the whole climate file (5 days), which includes a leaf-on event and a
   // leaf-off event
   while (climate != NULL) {
@@ -112,13 +109,9 @@ int testBalanceLeafNegativeLeafOnN(void) {
   logTest("Starting testBalanceLeafNegativeLeafOnN()\n");
   int status = 0;
   ClimateNode *originalClimate = climate;
-  double originalLeafOnDay = params.leafOnDay;
-  double originalLeafOffDay = params.leafOffDay;
   double originalLeafCN = params.leafCN;
   double originalWoodCN = params.woodCN;
 
-  // Keep leaf-on/off timing from balance.param so the simulation actually hits
-  // a leaf-on transition and exercises the negative leaf-on N case.
   params.leafCN = 20.0;
   params.woodCN = 10.0;
 
@@ -132,8 +125,6 @@ int testBalanceLeafNegativeLeafOnN(void) {
   }
 
   climate = originalClimate;
-  params.leafOnDay = originalLeafOnDay;
-  params.leafOffDay = originalLeafOffDay;
   params.leafCN = originalLeafCN;
   params.woodCN = originalWoodCN;
   return status;
@@ -195,14 +186,17 @@ int run(void) {
   status |= testBalanceLeafNegativeLeafOnN();
   reset();
 
+  status |= testBalanceNoLitterPool();
+  reset();
+
   // Re-initialize events with leaf on/off events for the next test
+  params.leafOffDay = 0;
+  params.leafOnDay = 0;
   closeEventOutFile();
   initEvents("events_leaf.in", "events.out", 0);
   setupEvents();
   status |= testBalanceLeafEvents();
   reset();
-
-  status |= testBalanceNoLitterPool();
 
   return status;
 }

--- a/tests/sipnet/test_modeling/testBalance.c
+++ b/tests/sipnet/test_modeling/testBalance.c
@@ -108,6 +108,37 @@ int testBalanceLeaf(void) {
   return status;
 }
 
+int testBalanceLeafNegativeLeafOnN(void) {
+  logTest("Starting testBalanceLeafNegativeLeafOnN()\n");
+  int status = 0;
+  ClimateNode *originalClimate = climate;
+  double originalLeafOnDay = params.leafOnDay;
+  double originalLeafOffDay = params.leafOffDay;
+  double originalLeafCN = params.leafCN;
+  double originalWoodCN = params.woodCN;
+
+  // Keep leaf-on/off timing from balance.param so the simulation actually hits
+  // a leaf-on transition and exercises the negative leaf-on N case.
+  params.leafCN = 20.0;
+  params.woodCN = 10.0;
+
+  while (climate != NULL) {
+    step();
+
+    status |= checkCarbon();
+    status |= checkNitrogen();
+
+    climate = climate->nextClim;
+  }
+
+  climate = originalClimate;
+  params.leafOnDay = originalLeafOnDay;
+  params.leafOffDay = originalLeafOffDay;
+  params.leafCN = originalLeafCN;
+  params.woodCN = originalWoodCN;
+  return status;
+}
+
 int testBalanceLeafEvents(void) {
   logTest("Starting testBalanceLeafEvents()\n");
   int status = 0;
@@ -159,6 +190,9 @@ int run(void) {
   reset();
 
   status |= testBalanceLeaf();
+  reset();
+
+  status |= testBalanceLeafNegativeLeafOnN();
   reset();
 
   // Re-initialize events with leaf on/off events for the next test

--- a/tests/sipnet/test_modeling/testNitrogenCycle.c
+++ b/tests/sipnet/test_modeling/testNitrogenCycle.c
@@ -263,6 +263,25 @@ void doNFixUpLimitCalcs(void) {
   checkNitrogenLimitation();
 }
 
+int testLeafOnNFromC(void) {
+  int status = 0;
+  double leafOnC = 50.0;
+  double originalLeafCN = params.leafCN;
+  double originalWoodCN = params.woodCN;
+  logTest("Running testLeafOnNFromC\n");
+
+  params.leafCN = 20.0;
+  params.woodCN = 100.0;
+  status |= checkFlux(calcLeafOnNFromC(leafOnC), 2.0, "positive leaf-on N");
+
+  params.woodCN = 10.0;
+  status |= checkFlux(calcLeafOnNFromC(leafOnC), -2.5, "negative leaf-on N");
+
+  params.leafCN = originalLeafCN;
+  params.woodCN = originalWoodCN;
+  return status;
+}
+
 int testNFixation(void) {
   int status = 0;
   double minN;
@@ -822,6 +841,7 @@ int run(void) {
   status |= testFertilization();
   status |= testNLeaching();
   status |= testOrganicN();
+  status |= testLeafOnNFromC();
   status |= testNFixation();
   status |= testNLimitation();
   status |= testNLimitationWithStorage();


### PR DESCRIPTION
## Summary

- **What**: Remove `fmax` clip in calcLeafOnNFromC
- **Motivation**: In the rare event that woodCN < leafCN, this function will drop N, causing an N balance check failure

## How was this change tested?
List steps taken to test this change, with appropriate outputs if applicable

* All existing smoke and unit tests pass
* Test points added to testNitrogenCycle.c and testBalance.c to check new code

Thanks to the new testBalance check, also verified that we do indeed have a balance failure if the `fmax` is left in.

## Related issues

- Fixes #377

## Checklist

- [x] Related issues are listed above. [PRs without an approved, related issue may not get reviewed](docs/CONTRIBUTING.md#propose-and-receive-feedback).
- [x] PR title has the issue number in it ("[#<number>] \<concise description of proposed change>")
- [x] Tests added/updated for new features (if applicable)
- [x] Documentation updated (if applicable)
- [x] `docs/CHANGELOG.md` updated with noteworthy changes
- [x] Code formatted with `clang-format` (run `git clang-format` if needed)
