### PR TITLE
Fix typo in doSingleOutputs context name

### DIFF
--- a/src/common/context.c
+++ b/src/common/context.c
@@ -47,7 +47,7 @@ void initContext(void) {
 
   // Flags, I/O
   CREATE_INT_CONTEXT(doMainOutput,    "DO_MAIN_OUTPUT",   ARG_ON,  FLAG_YES);
-  CREATE_INT_CONTEXT(doSingleOutputs, "DO_SINGLE_OUTPUT", ARG_OFF, FLAG_YES);
+  CREATE_INT_CONTEXT(doSingleOutputs, "DO_SINGLE_OUTPUTS", ARG_OFF, FLAG_YES);
   CREATE_INT_CONTEXT(dumpConfig,      "DUMP_CONFIG",      ARG_OFF, FLAG_YES);
   CREATE_INT_CONTEXT(printHeader,     "PRINT_HEADER",     ARG_ON,  FLAG_YES);
   CREATE_INT_CONTEXT(quiet,           "QUIET",            ARG_OFF, FLAG_YES);

--- a/tests/smoke/niwot/sipnet.config
+++ b/tests/smoke/niwot/sipnet.config
@@ -3,7 +3,7 @@
             CLIM_FILE    CALCULATED      sipnet.clim
      DEBUG_LOG_PREFIX       DEFAULT                 
        DO_MAIN_OUTPUT    INPUT_FILE                1
-     DO_SINGLE_OUTPUTS    INPUT_FILE                0
+    DO_SINGLE_OUTPUTS    INPUT_FILE                0
           DUMP_CONFIG    INPUT_FILE                1
                EVENTS       DEFAULT                1
         EVENTS_PREFIX       DEFAULT           events

--- a/tests/smoke/niwot/sipnet.config
+++ b/tests/smoke/niwot/sipnet.config
@@ -3,7 +3,7 @@
             CLIM_FILE    CALCULATED      sipnet.clim
      DEBUG_LOG_PREFIX       DEFAULT                 
        DO_MAIN_OUTPUT    INPUT_FILE                1
-     DO_SINGLE_OUTPUT    INPUT_FILE                0
+     DO_SINGLE_OUTPUTS    INPUT_FILE                0
           DUMP_CONFIG    INPUT_FILE                1
                EVENTS       DEFAULT                1
         EVENTS_PREFIX       DEFAULT           events

--- a/tests/smoke/russell_1/sipnet.config
+++ b/tests/smoke/russell_1/sipnet.config
@@ -5,7 +5,7 @@ Final config for SIPNET run at 2026-08-03 15:01:40 UTC
             CLIM_FILE    CALCULATED      sipnet.clim
      DEBUG_LOG_PREFIX       DEFAULT                 
        DO_MAIN_OUTPUT       DEFAULT                1
-     DO_SINGLE_OUTPUT       DEFAULT                0
+     DO_SINGLE_OUTPUTS       DEFAULT                0
           DUMP_CONFIG    INPUT_FILE                1
                EVENTS       DEFAULT                1
         EVENTS_PREFIX       DEFAULT           events

--- a/tests/smoke/russell_1/sipnet.config
+++ b/tests/smoke/russell_1/sipnet.config
@@ -1,11 +1,11 @@
-Final config for SIPNET run at 2026-08-03 15:01:40 UTC
+Final config for SIPNET run at 2026-08-29 02:02:30 UTC
                  Name        Source            Value
             ANAEROBIC       DEFAULT                0
     CARBON_SATURATION       DEFAULT                0
             CLIM_FILE    CALCULATED      sipnet.clim
      DEBUG_LOG_PREFIX       DEFAULT                 
        DO_MAIN_OUTPUT       DEFAULT                1
-     DO_SINGLE_OUTPUTS       DEFAULT                0
+    DO_SINGLE_OUTPUTS       DEFAULT                0
           DUMP_CONFIG    INPUT_FILE                1
                EVENTS       DEFAULT                1
         EVENTS_PREFIX       DEFAULT           events

--- a/tests/smoke/russell_2/sipnet.config
+++ b/tests/smoke/russell_2/sipnet.config
@@ -5,7 +5,7 @@ Final config for SIPNET run at 2026-07-14 18:34:57 UTC
             CLIM_FILE    CALCULATED      sipnet.clim
      DEBUG_LOG_PREFIX       DEFAULT                 
        DO_MAIN_OUTPUT    INPUT_FILE                1
-     DO_SINGLE_OUTPUT    INPUT_FILE                0
+     DO_SINGLE_OUTPUTS    INPUT_FILE                0
           DUMP_CONFIG    INPUT_FILE                1
                EVENTS    INPUT_FILE                1
         EVENTS_PREFIX       DEFAULT           events

--- a/tests/smoke/russell_2/sipnet.config
+++ b/tests/smoke/russell_2/sipnet.config
@@ -1,11 +1,11 @@
-Final config for SIPNET run at 2026-07-14 18:34:57 UTC
+Final config for SIPNET run at 2026-08-29 02:02:30 UTC
                  Name        Source            Value
             ANAEROBIC    INPUT_FILE                1
     CARBON_SATURATION       DEFAULT                0
             CLIM_FILE    CALCULATED      sipnet.clim
      DEBUG_LOG_PREFIX       DEFAULT                 
        DO_MAIN_OUTPUT    INPUT_FILE                1
-     DO_SINGLE_OUTPUTS    INPUT_FILE                0
+    DO_SINGLE_OUTPUTS    INPUT_FILE                0
           DUMP_CONFIG    INPUT_FILE                1
                EVENTS    INPUT_FILE                1
         EVENTS_PREFIX       DEFAULT           events

--- a/tests/smoke/russell_3/sipnet.config
+++ b/tests/smoke/russell_3/sipnet.config
@@ -1,11 +1,11 @@
-Final config for SIPNET run at 2026-07-14 18:34:57 UTC
+Final config for SIPNET run at 2026-08-29 02:02:31 UTC
                  Name        Source            Value
             ANAEROBIC       DEFAULT                0
     CARBON_SATURATION       DEFAULT                0
             CLIM_FILE    CALCULATED      sipnet.clim
      DEBUG_LOG_PREFIX       DEFAULT                 
        DO_MAIN_OUTPUT       DEFAULT                1
-     DO_SINGLE_OUTPUTS       DEFAULT                0
+    DO_SINGLE_OUTPUTS       DEFAULT                0
           DUMP_CONFIG    INPUT_FILE                1
                EVENTS       DEFAULT                1
         EVENTS_PREFIX       DEFAULT           events

--- a/tests/smoke/russell_3/sipnet.config
+++ b/tests/smoke/russell_3/sipnet.config
@@ -5,7 +5,7 @@ Final config for SIPNET run at 2026-07-14 18:34:57 UTC
             CLIM_FILE    CALCULATED      sipnet.clim
      DEBUG_LOG_PREFIX       DEFAULT                 
        DO_MAIN_OUTPUT       DEFAULT                1
-     DO_SINGLE_OUTPUT       DEFAULT                0
+     DO_SINGLE_OUTPUTS       DEFAULT                0
           DUMP_CONFIG    INPUT_FILE                1
                EVENTS       DEFAULT                1
         EVENTS_PREFIX       DEFAULT           events

--- a/tests/smoke/russell_4/sipnet.config
+++ b/tests/smoke/russell_4/sipnet.config
@@ -2,7 +2,7 @@ Final config for SIPNET run at 2026-02-05 22:12:57 UTC
                  Name        Source           Value
             CLIM_FILE    CALCULATED     sipnet.clim
        DO_MAIN_OUTPUT       DEFAULT               1
-     DO_SINGLE_OUTPUT       DEFAULT               0
+     DO_SINGLE_OUTPUTS       DEFAULT               0
           DUMP_CONFIG    INPUT_FILE               1
                EVENTS    INPUT_FILE               0
             FILE_PREFIX       DEFAULT          sipnet


### PR DESCRIPTION
TYPO identified in https://github.com/PecanProject/sipnet/pull/380/changes#r3884528855
