### PR TITLE
Don't require link-check success for PR merge

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -33,7 +33,7 @@ jobs:
             --exclude '^https://russellranch\.ucdavis\.edu'
             --exclude '^https://join\.slack\.com'
             .
-          fail: true
+          fail: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Link checker fails too often for reasons unrelated to a PR. It is sufficient to be notified of broken links.
